### PR TITLE
update gcefca because redirects are broken in stage

### DIFF
--- a/env/dev/values.yaml
+++ b/env/dev/values.yaml
@@ -48,7 +48,7 @@ serviceMonitor:
     - name: develop-flibble
       url: https://www-dev.greenpeace.org/flibble
     - name: develop-gcefca
-      url: https://www-dev.greenpeace.org/gcefca
+      url: https://www-dev.greenpeace.org/gcefca/en/
     - name: develop-greece
       url: https://www-dev.greenpeace.org/greece
     - name: develop-greenland

--- a/env/prod/values.yaml
+++ b/env/prod/values.yaml
@@ -44,7 +44,7 @@ serviceMonitor:
     - name: flibble-release
       url: https://www-stage.greenpeace.org/flibble
     - name: gcefca-release
-      url: https://www-stage.greenpeace.org/gcefca
+      url: https://www-stage.greenpeace.org/gcefca/en/
     - name: greece-release
       url: https://www-stage.greenpeace.org/greece
     - name: greenland-release


### PR DESCRIPTION
As advised by pieter this is the url we should use.

IMO its not great because its possible it will just stay like this if we arent reminded to keep trying to get this fixed